### PR TITLE
Fix highlight and strikethrough formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -1399,13 +1399,11 @@
             if (range.collapsed || !noteContent.contains(sel.anchorNode)) return;
 
             if (tag === 'mark') {
-                toggleWrapper(range, 'mark');
-            } else if (tag === 'del') {
-                toggleWrapper(range, 'del');
+                document.execCommand('hiliteColor', false, 'yellow');
             } else {
                 document.execCommand(commandMap[tag]);
-                normalizeFormatting();
             }
+            normalizeFormatting();
 
             hideFormatToolbar();
             autoSaveNote();


### PR DESCRIPTION
## Summary
- fix highlight and strikethrough buttons so they apply actual formatting in notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f516237688329b6bafdc9cb86f67f