### PR TITLE
Fix strikethrough/highlight toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1399,7 +1399,9 @@
             if (range.collapsed || !noteContent.contains(sel.anchorNode)) return;
 
             if (tag === 'mark') {
-                document.execCommand('hiliteColor', false, 'yellow');
+                toggleWrapper(range, 'mark');
+            } else if (tag === 'del') {
+                toggleWrapper(range, 'del');
             } else {
                 document.execCommand(commandMap[tag]);
             }


### PR DESCRIPTION
## Summary
- make strikethrough and highlight buttons toggle formatting

## Testing
- `tidy -q -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f53aaf4bc832998e647260dc7b2b5