### PR TITLE
Remove highlight and strikethrough buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -869,9 +869,7 @@
                         <div id="formatToolbar" class="format-toolbar" style="display:none;">
                             <button data-tag="strong">B</button>
                             <button data-tag="em">I</button>
-                            <button data-tag="del">S</button>
                             <button data-tag="u">U</button>
-                            <button data-tag="mark">🟨</button>
                         </div>
                     </div>
                     <div id="emptyState" class="empty-state">


### PR DESCRIPTION
## Summary
- trim the note formatting toolbar by removing the yellow highlight and strike-through buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f5e4cf668832995c711c23a3d9098