### PR TITLE
Improve mood modal UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,6 +378,12 @@
             display: flex;
             align-items: center;
             gap: 0.5rem;
+            flex-wrap: nowrap;
+        }
+
+        .break-duration-text {
+            font-size: 0.85rem;
+            white-space: nowrap;
         }
 
         .task-tags {
@@ -843,12 +849,27 @@
 
         .modal-btn {
             flex: 1;
-            padding: 0.75rem;
+            padding: 0.6rem 1.2rem;
             border: none;
             border-radius: 8px;
             cursor: pointer;
-            font-size: 1rem;
+            font-size: 0.9rem;
             transition: background 0.2s;
+            position: relative;
+        }
+
+        .modal-btn[title]:hover::after {
+            content: attr(title);
+            position: absolute;
+            bottom: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            background: #4a5568;
+            color: white;
+            padding: 0.5rem;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            white-space: nowrap;
         }
 
         .modal-btn.primary {
@@ -1523,7 +1544,7 @@
     <div class="modal unified-modal" id="moodReasonModal">
         <div class="modal-content">
             <button class="modal-close" onclick="closeMoodReasonModal()">❌</button>
-            <h3>Want to share why you felt this way?</h3>
+            <h3 id="moodReasonHeader">Want to share why you felt this way?</h3>
             <input type="text" id="moodReasonInput" class="modal-input" placeholder="Optional reason">
             <div id="breakSuggestion" style="display:none;">
                 <p style="margin-bottom:0.5rem;">💬 Sounds like it might be time for a break. Want to try breaking your task down first?</p>
@@ -1534,7 +1555,7 @@
                 </div>
                 <button id="addBreakStep" class="add-break-item">➕ Add</button>
                 <div class="break-duration-section">
-                    <span>Take a break for:</span>
+                    <span class="break-duration-text">Break time:</span>
                     <input type="number" id="breakDuration" value="15" min="1" style="width:60px;">
                     <span>min</span>
                     <button class="modal-btn primary" id="startBreakBtn">Start Break</button>
@@ -1542,10 +1563,8 @@
                 <div id="breakError" class="break-error"></div>
             </div>
             <div class="modal-actions" style="margin-top:1.5rem;">
-                <button class="modal-btn primary" id="saveMoodReason">Save Tasks Only</button>
-                <div class="floating-msg">Save without starting break</div>
-                <button class="modal-btn secondary" id="skipMoodReason">Cancel</button>
-                <div class="floating-msg">Skip without saving anything</div>
+                <button class="modal-btn primary" id="saveMoodReason" title="Save without starting break">Save Tasks</button>
+                <button class="modal-btn secondary" id="skipMoodReason" title="Skip without saving anything">Skip</button>
             </div>
         </div>
     </div>
@@ -2391,6 +2410,12 @@
                     const eElapsed = (entry.minutesIntoTask !== null && entry.minutesIntoTask !== undefined) ? entry.minutesIntoTask : entry.elapsed;
                     const taskInfo = entry.task ? `During "${entry.task}" (${eElapsed} min in)` : 'No task active';
                     div.textContent = `${entry.mood} – ${formatTime(entry.date)} – ${taskInfo}`;
+                    if (entry.reason) {
+                        const reasonDiv = document.createElement('div');
+                        reasonDiv.className = 'mood-reason';
+                        reasonDiv.textContent = `"${entry.reason}"`;
+                        div.appendChild(reasonDiv);
+                    }
                 } else {
                     div.textContent = `Break – ${entry.duration} mins ended at ${formatTime(entry.date)}`;
                 }
@@ -2564,10 +2589,16 @@
             modal.classList.add('active');
             input.focus();
             document.getElementById('breakError').style.display = 'none';
+            const header = document.getElementById('moodReasonHeader');
             const suggestion = document.getElementById('breakSuggestion');
-            if (mood === '😩' || mood === '😠') {
+            if (mood === '😩') {
+                header.textContent = "Feeling tired? Let's understand what's draining you.";
+                suggestion.style.display = 'block';
+            } else if (mood === '😠') {
+                header.textContent = "Feeling overwhelmed? Let's identify what's causing stress.";
                 suggestion.style.display = 'block';
             } else {
+                header.textContent = 'Want to share why you felt this way?';
                 suggestion.style.display = 'none';
             }
         }


### PR DESCRIPTION
## Summary
- convert floating messages to tooltips
- tighten button styles and copy
- keep break duration input in one line
- show mood reason in mood timeline
- add empathetic messaging for tired/stressed moods

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881cb243b1483299543306c110beea7