### PR TITLE
Fix truncated modal button text

### DIFF
--- a/index.html
+++ b/index.html
@@ -848,6 +848,12 @@
             margin-top: 1.5rem;
         }
 
+        @media (max-width: 400px) {
+            .modal-actions {
+                flex-direction: column;
+            }
+        }
+
         .modal-btn {
             flex: 1;
             padding: 0.75rem 1rem;
@@ -857,9 +863,6 @@
             font-size: 0.85rem;
             transition: background 0.2s;
             position: relative;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
             line-height: 1.2;
         }
 


### PR DESCRIPTION
## Summary
- fix text cutoff for completion modal buttons by allowing wrapping
- stack modal buttons vertically on small screens

## Testing
- `htmlhint index.html` *(fails: command not found)*
- `tidy -errors index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881eb5bff948329bb153c6150a48538