### PR TITLE
Fix timer button rendering when a timer is active

### DIFF
--- a/index.html
+++ b/index.html
@@ -2102,7 +2102,7 @@
                     `</ul></div>`
                     : `<div class='task-subtasks'></div>`;
 
-                const timerBtn = (currentTaskIndex !== idx && !isActive)
+                const timerBtn = (currentTaskIndex !== idx && !isActive && pinnedTaskIndex === null)
                     ? `<button class='timer-task' onclick='startTaskTimer(${idx})'>⏱️</button>`
                     : '';
 


### PR DESCRIPTION
## Summary
- hide timer buttons on all tasks while any task timer is running

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881f5044a7c83299287222402e00dce