### PR TITLE
Adjust trend tooltip width and centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,20 +506,22 @@
 
         .trend-wrapper {
             position: relative;
-            display: inline-block;
+            display: block;
+            text-align: center;
         }
 
         .trend-tooltip {
             position: absolute;
-            left: 0;
+            left: 50%;
             top: calc(100% + 8px);
             background: var(--soft-brown);
             border-radius: 12px;
             box-shadow: 0 2px 8px rgba(0,0,0,0.06);
             padding: 0.75rem;
-            max-width: 300px;
+            width: 90%;
+            max-width: none;
             opacity: 0;
-            transform: scale(0.95) translateY(10px);
+            transform: translateX(-50%) scale(0.95) translateY(10px);
             transition: opacity 0.2s ease, transform 0.2s ease;
             pointer-events: none;
             z-index: 5;
@@ -527,7 +529,7 @@
 
         .trend-tooltip.show {
             opacity: 1;
-            transform: scale(1) translateY(0);
+            transform: translateX(-50%) scale(1) translateY(0);
             pointer-events: auto;
         }
 
@@ -535,7 +537,8 @@
             content: '';
             position: absolute;
             top: -6px;
-            left: 20px;
+            left: 50%;
+            transform: translateX(-50%);
             border-width: 6px;
             border-style: solid;
             border-color: transparent transparent var(--soft-brown) transparent;


### PR DESCRIPTION
## Summary
- widen the mood trend tooltip and center it relative to the card

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882fa9e7048832987e03f387cc3dccd