### PR TITLE
Improve trend tooltip layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,7 +510,6 @@
         }
 
         .trend-wrapper {
-            position: relative;
             display: block;
             text-align: center;
         }
@@ -519,12 +518,15 @@
             display: flex;
             flex-direction: column;
             gap: 0.5rem;
+            margin-top: 0.75rem;
         }
 
         .trend-buttons {
             display: flex;
             justify-content: center;
             gap: 1rem;
+            position: relative;
+            width: 100%;
         }
 
         .trend-tag {
@@ -545,7 +547,7 @@
             border-radius: 12px;
             box-shadow: 0 2px 8px rgba(0,0,0,0.06);
             padding: 0.75rem;
-            width: 90%;
+            width: 95%;
             max-width: none;
             opacity: 0;
             transform: translateX(-50%) scale(0.95) translateY(10px);


### PR DESCRIPTION
## Summary
- widen mood trend and energy insights tooltips
- center tooltips to the mood card
- add breathing space above the "View all" button

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68830da40de88329ae53d979a589037c