### PR TITLE
Add muted brown scrollbars

### DIFF
--- a/index.html
+++ b/index.html
@@ -1441,14 +1441,39 @@
             padding: 0.5rem;
         }
 
-        .delete-subtask {
-            background: none;
-            border: none;
-            color: #e2b1b1;
-            cursor: pointer;
-            font-size: 1rem;
-            margin-left: 0.25rem;
-        }
+.delete-subtask {
+    background: none;
+    border: none;
+    color: #e2b1b1;
+    cursor: pointer;
+    font-size: 1rem;
+    margin-left: 0.25rem;
+}
+
+/* Scrollbar styling for a muted brown theme */
+::-webkit-scrollbar {
+    width: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: var(--soft-brown);
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb {
+    background: #c9b3a3;
+    border-radius: 4px;
+    border: 1px solid #f0ede8;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: #b8a191;
+}
+
+html {
+    scrollbar-width: thin;
+    scrollbar-color: #c9b3a3 var(--soft-brown);
+}
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- customize scrollbars with muted brown hues to match the planner's theme

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6883122c16f48329abd7594a7882f4e3