### PR TITLE
Fix halfway modal trigger

### DIFF
--- a/index.html
+++ b/index.html
@@ -3924,7 +3924,10 @@ function openSubtaskModal(tIndex) {
             taskTimerInterval = setInterval(() => {
                 if (taskTimeRemaining > 0) {
                     taskTimeRemaining--;
-                    if (!halfwayPrompted && taskOriginalDuration >= 15 * 60 && taskTimeRemaining <= taskOriginalDuration / 2) {
+                    if (taskTimeRemaining % 30 === 0) {
+                        console.log('Timer check:', taskTimeRemaining, 'of', taskOriginalDuration, 'halfway at:', taskOriginalDuration/2);
+                    }
+                    if (!halfwayPrompted && taskOriginalDuration >= 10 * 60 && taskTimeRemaining <= taskOriginalDuration / 2) {
                         halfwayPrompted = true;
                         openMoodPromptModal('midway');
                     }


### PR DESCRIPTION
## Summary
- lower halfway modal timer threshold from 15 to 10 minutes
- add console debug logging to track countdown progress

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688326d7f1608329a2a72a6bd37eedec